### PR TITLE
Enable message property addition

### DIFF
--- a/Xpirit-Vsts-Build-AzureServiceBus/task.json
+++ b/Xpirit-Vsts-Build-AzureServiceBus/task.json
@@ -69,6 +69,14 @@
         "rows": "5"
       }
     }
+    {
+      "name": "CustomMessageProperties",
+      "type": "string",
+      "label": "Custom message properties",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Custom message properties sent along with header. Key-value pairs separated by semicolon"
+    }
   ],
   "instanceNameFormat": "Post to Azure Service Bus",
   "execution": {

--- a/Xpirit-Vsts-Build-AzureServiceBus/task.json
+++ b/Xpirit-Vsts-Build-AzureServiceBus/task.json
@@ -75,7 +75,7 @@
       "label": "Custom message properties",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Custom message properties sent along with header. Key-value pairs separated by semicolon"
+      "helpMarkDown": "Custom message properties sent along with header. Key-value pairs separated by semicolon, e.g. key1=value1;key2=value2"
     }
   ],
   "instanceNameFormat": "Post to Azure Service Bus",


### PR DESCRIPTION
Enable adding custom message properties. The property can be used as filter to determine if the message should deliver to a specific queue/topic or subscription.

This is basically inserting key-value pairs in HTTP header.